### PR TITLE
feat: Input 공통 컴포넌트 작업

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "typescript": "~5.6.2",
     "typescript-eslint": "^8.11.0",
     "vite": "^5.4.10",
-    "vite-tsconfig-paths": "^5.1.2"
+    "vite-tsconfig-paths": "^5.1.2",
+    "zustand": "^5.0.1"
   }
 }

--- a/src/shared/components/atoms/Input.tsx
+++ b/src/shared/components/atoms/Input.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import useInputStore from '@/store/useInputStore';
+import { InputProps } from '@/shared/interface/atomsType';
+
+const Input: React.FC<InputProps> = ({ title, placeholder, name, description, maxLength }) => {
+  const { inputs, setInput } = useInputStore();
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setInput(name, e.target.value);
+    // TODO: 데이터 확인용, 작업 후 삭제 예정
+    console.log(e.target.value);
+  };
+
+  return (
+    <div className="mb-[1rem] text-center">
+      {title && <label className="block mb-[0.25rem]">{title}</label>}
+      <input
+        type="text"
+        placeholder={placeholder}
+        name={name}
+        value={inputs[name] || ''}
+        onChange={handleChange}
+        maxLength={maxLength}
+        className="w-[20rem] h-[3.5rem] mt-[0.5rem] px-[1rem] py-[0.5rem] border border-input rounded-[0.25rem] placeholder-input focus:outline-none  focus:ring-transparent focus:border-main  focus:ring-0 focus:ring-main"
+      />
+      {description && <p className="text-[0.75rem] mt-[0.5rem] text-input">{description}</p>}
+    </div>
+  );
+};
+
+export default Input;

--- a/src/shared/interface/atomsType.ts
+++ b/src/shared/interface/atomsType.ts
@@ -4,3 +4,11 @@ export interface NavItemProps {
   path: string;
   isSelected: boolean;
 }
+
+export interface InputProps {
+  name: string;
+  title?: string;
+  placeholder: string;
+  description?: string;
+  maxLength: number;
+}

--- a/src/store/storeType.ts
+++ b/src/store/storeType.ts
@@ -1,0 +1,5 @@
+export interface InputStore {
+  inputs: Record<string, string>;
+  setInput: (name: string, value: string) => void;
+  resetInputs: () => void;
+}

--- a/src/store/useInputStore.ts
+++ b/src/store/useInputStore.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand';
+import { InputStore } from '@store/storeType';
+
+const useInputStore = create<InputStore>((set) => ({
+  inputs: {},
+  setInput: (name, value) =>
+    set((state) => ({
+      inputs: { ...state.inputs, [name]: value },
+    })),
+  resetInputs: () => set({ inputs: {} }),
+}));
+
+export default useInputStore;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -12,6 +12,7 @@ export default {
         main: '#748D70',
         active: '#455C3F',
         highlight: '#0B4203',
+        input: '#D2D2D2',
         disabled: '#D9D9D9',
         disabledHover: '#999999',
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3145,3 +3145,8 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zustand@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/zustand/-/zustand-5.0.1.tgz#2bdca5e4be172539558ce3974fe783174a48fdcf"
+  integrity sha512-pRET7Lao2z+n5R/HduXMio35TncTlSW68WsYBq2Lg1ASspsNGjpwLAsij3RpouyV6+kHMwwwzP0bZPD70/Jx/w==


### PR DESCRIPTION
### 구현 내용
**주요 기능**: 공통으로 사용할 Input 컴포넌트 작업

**디자인/구현상의 결정 사항**:
- 색상 공통 사용을 위해 input color theme에 `input` 컬러 추가
- 중앙 상태 관리를 위해 `zustand` 설치
- 공통으로 사용하기 위한 `Input` 컴포넌트 작업
- Input 상태 중앙 관리를 위한 `useInputStore` Store 추가
- input 작성 시 console.log에 value 확인 가능

### 스크린샷/기타 자료
![image](https://github.com/user-attachments/assets/2629c1a8-b241-4260-8425-76cca258d5ad)
