### PR TITLE
feat: 회원가입 UI 작업

### DIFF
--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -1,5 +1,57 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import useInputStore from '@/store/useInputStore';
+import Button from '@/shared/components/atoms/Button';
+import Input from '@/shared/components/atoms/Input';
+import Title from '@/shared/components/atoms/Title';
+import { isValidId, isValidPassword } from '@/utils/validation';
+
 function SignUp() {
-  return <div>회원가입</div>;
+  const navigate = useNavigate();
+  const { inputs, resetInputs } = useInputStore();
+  const { id, password, passwordCheck } = inputs;
+  const [disabledBtn, setDisabledBtn] = useState(true);
+
+  const handleClick = () => {
+    if (id && password && passwordCheck) {
+      console.log(id, password, passwordCheck); //TODO: 데이터 확인 용, 백엔드 작업 후 삭제 예정
+      resetInputs();
+      navigate('/');
+    }
+  };
+
+  useEffect(() => {
+    if (id && password && passwordCheck) {
+      setDisabledBtn(false);
+    }
+  }, [id, password, passwordCheck]);
+
+  return (
+    <div className="flex flex-col justify-center items-center h-full">
+      <Title>회원가입</Title>
+      <div className="flex flex-col gap-3">
+        <div>
+          <Input theme="auth" name="id" placeholder="아이디 입력" maxLength={20} />
+          {id && !isValidId(id) && (
+            <p className="mt-1 text-[#ff4949]">4-20자, 최소 하나의 영문자가 포함되도록 작성해주세요.</p>
+          )}
+        </div>
+        <div>
+          <Input theme="auth" type="password" name="password" placeholder="비밀번호 입력" maxLength={20} />
+          {password && !isValidPassword(password) && (
+            <p className="mt-1 text-[#ff4949]">최소 8자, 하나 이상의 영문(대소문자), 숫자, 특수 문자를 포함해주세요.</p>
+          )}
+        </div>
+        <div>
+          <Input theme="auth" type="password" name="passwordCheck" placeholder="비밀번호 확인" maxLength={20} />
+          {password !== passwordCheck && <p className="mt-1 text-[#ff4949]">비밀번호가 일치하지 않습니다.</p>}
+        </div>
+        <Button event={handleClick} theme="auth" disabled={disabledBtn}>
+          가입하기
+        </Button>
+      </div>
+    </div>
+  );
 }
 
 export default SignUp;

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -23,6 +23,8 @@ function SignUp() {
   useEffect(() => {
     if (id && password && passwordCheck) {
       setDisabledBtn(false);
+    } else {
+      setDisabledBtn(true);
     }
   }, [id, password, passwordCheck]);
 

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,0 +1,21 @@
+/**
+ * 아이디 유효성 검사 함수
+ * - 조건: 영문자(소문자 필수) + 선택적으로 숫자, `_` 포함. 4~20자
+ * @param id - 검사할 아이디 문자열
+ * @returns boolean - 유효성 검사 결과
+ */
+export const isValidId = (id: string): boolean => {
+  const idRegex = /^(?=.*[a-z])[a-z0-9_]{4,20}$/;
+  return idRegex.test(id);
+};
+
+/**
+ * 비밀번호 유효성 검사 함수
+ * - 조건: 8-64자, 하나 이상의 영문(대소문자), 숫자, 특수 문자 포함
+ * @param password - 검사할 비밀번호 문자열
+ * @returns boolean - 유효성 검사 결과
+ */
+export const isValidPassword = (password: string): boolean => {
+  const passwordRegex = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*?&#])[A-Za-z\d@$!%*?&#]{8,64}$/;
+  return passwordRegex.test(password);
+};


### PR DESCRIPTION
### 구현 내용

**주요 기능**: 회원가입 UI 작업
**디자인/구현상의 결정 사항**: 
- 아이디/비밀번호 정규식 조건
  - **아이디**: 영문자(소문자)로 이루어진 4~20자. (숫자, _ 가능)
  - **비밀번호**: 8-64자, 하나 이상의 영문(대소문자), 숫자, 특수 문자 포함.

### 스크린샷/기타 자료
![image](https://github.com/user-attachments/assets/d4f55497-a0a0-4a64-ada1-23ed9268cad6)
- 회원가입 ui 작업

![image](https://github.com/user-attachments/assets/af7a62e6-70d2-4b0b-957c-6398692e6b3f)
- 아이디/비밀번호 조건에 맞지 않을 경우 설명 텍스트가 아래 나타나도록 작업 

![image](https://github.com/user-attachments/assets/605b16d1-61b9-41a5-862f-f2c38b4bd82c)
- input 중 하나라도 빈 값일 경우 버튼 비활성화
